### PR TITLE
fix(s3-regions): Fix to Support All Region Endpoints for S3

### DIFF
--- a/modules/compute/data.tf
+++ b/modules/compute/data.tf
@@ -21,6 +21,7 @@ data "aws_region" "current" {}
 data "template_file" "user_data_template" {
   template = file("${path.module}/templates/user_data_script.sh.tpl")
   vars = {
+    aws_region             = data.aws_region.current.name
     enable_rcon            = "${var.enable_rcon}"
     rcon_port              = var.enable_rcon == true ? "${var.rcon_port}" : ""
     enable_session_manager = var.enable_session_manager

--- a/modules/compute/templates/user_data_script.sh.tpl
+++ b/modules/compute/templates/user_data_script.sh.tpl
@@ -96,7 +96,7 @@ retrieve_obj_from_s3() {
     exit_script 10
   else
     echo "[INFO] Copying $src to $dst..."
-    aws s3 cp "$src" "$dst"
+    aws s3 cp "$src" "$dst" --region ${aws_region}
     chown steam:steam /palworld-server/Pal/Saved/Config/LinuxServer/PalWorldSettings.ini
   fi
 }
@@ -164,7 +164,7 @@ retrieve_obj_from_s3_backup_levelData() {
   else
     mkdir -p "$dst"
     echo "[INFO] Copying $src to $dst..."
-    aws s3 sync "$src" "$dst"
+    aws s3 sync "$src" "$dst" --region ${aws_region}
   fi
 }
 
@@ -181,7 +181,7 @@ retrieve_obj_from_s3_backup_playerData() {
   else
     mkdir -p "$dst"
     echo "[INFO] Copying $src to $dst..."
-    aws s3 sync "$src" "$dst"
+    aws s3 sync "$src" "$dst" --region ${aws_region}
   fi
 }
 
@@ -198,7 +198,7 @@ retrieve_obj_from_existing_s3_levelData() {
   else
     mkdir -p "$dst"
     echo "[INFO] Copying $src to $dst..."
-    aws s3 sync "$src" "$dst"
+    aws s3 sync "$src" "$dst" --region ${aws_region}
   fi
 }
 
@@ -215,7 +215,7 @@ retrieve_obj_from_existing_s3_playerData() {
   else
     mkdir -p "$dst"
     echo "[INFO] Copying $src to $dst..."
-    aws s3 sync "$src" "$dst"
+    aws s3 sync "$src" "$dst" --region ${aws_region}
   fi
 }
 
@@ -322,8 +322,8 @@ tar -zcvf "\$BACKUP_FILENAME" "\$DIR_TO_BACKUP"
 
 # Upload backup to S3
 echo "[INFO] Uploading palworld Backup to s3"
-aws s3 cp "\$BACKUP_FILENAME" s3://"\$S3_BUCKET_NAME"/
-aws s3 cp "\$GUS_BACKUP" s3://"\$S3_BUCKET_NAME"/
+aws s3 cp "\$BACKUP_FILENAME" s3://"\$S3_BUCKET_NAME"/ --region ${aws_region}
+aws s3 cp "\$GUS_BACKUP" s3://"\$S3_BUCKET_NAME"/ --region ${aws_region}
 
 # Remove local backup file
 echo "[INFO] Removing Local palworld Backup File"


### PR DESCRIPTION
# Details
Fixes #15 

This doc https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#VirtualHostingBackwardsCompatibility explains that newer regions to not support the legacy global s3 endpoint. 

## Problem
Multiple functions in user_data contain the following aws or similar commands without region specified

```
aws s3 cp "$src" "$dst" 
```

This results in the following errors for newer regions trying to access s3 bucket objects:

```
An error occurred (IllegalLocationConstraintException) when calling the PutObject operation: The af-south-1 location constraint is incompatible for the region specific endpoint this request was sent to.
```

## Fix
Appended `--region ${aws_region}` to the end of all aws commands. AWS region is taken from a data source

```
data "aws_region" "current" {}
```

and interpolated into user_data

```
data "template_file" "user_data_template" {
  template = file("${path.module}/templates/user_data_script.sh.tpl")
  vars = {
    aws_region             = data.aws_region.current.name
..
..
}
```
